### PR TITLE
[codex] 차트 DSL에 값 표시와 축/격자 옵션 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ v1에서는 `bar`, `line`, `area`, `pie`만 지원합니다.
 ```txt
 chart bar
 x month
+show-values
+hide-grid
+y-range 0 2400
 series views | 조회수 | chart-1
 series likes | 좋아요 | chart-2
 
@@ -182,12 +185,17 @@ Mar | 1940 | 260
 
 - 첫 줄은 `chart <type>`
 - `x <field>`는 필수
+- `show-values`를 넣으면 각 데이터 값이 차트 위에 표시됩니다.
+- `hide-grid`를 넣으면 배경 격자선을 숨깁니다.
+- `y-range <min> <max>`를 넣으면 y축 범위를 고정합니다.
 - `series <key> | <label> | <theme-token>`은 1개 이상 필요
 - 빈 줄 뒤에 `data`
 - 다음 줄은 테이블 헤더
 - 데이터 값은 `|`로 구분
 
 색상 토큰은 `chart-1`부터 `chart-5`까지만 허용합니다.
+
+쉽게 말하면, 기본 문법은 그대로 두고 필요할 때만 `show-values`, `hide-grid`, `y-range` 같은 줄을 추가해서 차트 모양을 조절하는 방식입니다.
 
 ### Pie 차트
 
@@ -208,6 +216,7 @@ Edge | 132
 - `label <field>`는 항목 이름 필드
 - `value <field>`는 숫자 값 필드
 - 색상은 행 순서대로 `chart-1` ~ `chart-5`가 자동 배정
+- `show-values`, `hide-grid`, `y-range`는 pie 차트에서 지원하지 않습니다.
 
 ### 오류 처리
 
@@ -230,3 +239,4 @@ Jan | nope
 - `series`와 `data` 헤더 불일치
 - 숫자 필드에 숫자가 아닌 값 입력
 - 허용되지 않은 색상 토큰 사용
+- pie 차트에서 cartesian 전용 옵션 사용

--- a/src/components/mdx/chart.tsx
+++ b/src/components/mdx/chart.tsx
@@ -2,7 +2,7 @@
 
 import { AlertOctagon } from "lucide-react";
 import { Children, isValidElement, type ReactNode, useMemo, useState } from "react";
-import { Area, AreaChart, Bar, BarChart, CartesianGrid, Line, LineChart, Pie, PieChart, XAxis } from "recharts";
+import { Area, AreaChart, Bar, BarChart, CartesianGrid, LabelList, Line, LineChart, Pie, PieChart, XAxis, YAxis } from "recharts";
 import {
 	type CartesianChartSpec,
 	CHART_LEGEND_HEIGHT,
@@ -83,6 +83,18 @@ const cartesianChartComponents = {
 	area: AreaChart,
 } satisfies Record<CartesianChartSpec["type"], typeof BarChart | typeof LineChart | typeof AreaChart>;
 
+const formatChartValue = (value: string | number | boolean | null | undefined) => {
+	if (value == null || value === false) {
+		return "";
+	}
+
+	if (typeof value !== "number") {
+		return String(value);
+	}
+
+	return value.toLocaleString();
+};
+
 const renderCartesianSeries = (spec: CartesianChartSpec) => {
 	switch (spec.type) {
 		case "bar":
@@ -93,7 +105,16 @@ const renderCartesianSeries = (spec: CartesianChartSpec) => {
 					fill={`var(--color-${series.key})`}
 					radius={8}
 					isAnimationActive={false}
-				/>
+				>
+					{spec.options.showValues ? (
+						<LabelList
+							position="top"
+							offset={8}
+							formatter={formatChartValue}
+							className="fill-foreground text-[11px] font-medium"
+						/>
+					) : null}
+				</Bar>
 			));
 		case "line":
 			return spec.series.map((series) => (
@@ -105,7 +126,16 @@ const renderCartesianSeries = (spec: CartesianChartSpec) => {
 					strokeWidth={2}
 					dot={false}
 					isAnimationActive={false}
-				/>
+				>
+					{spec.options.showValues ? (
+						<LabelList
+							position="top"
+							offset={10}
+							formatter={formatChartValue}
+							className="fill-foreground text-[11px] font-medium"
+						/>
+					) : null}
+				</Line>
 			));
 		case "area":
 			return spec.series.map((series) => (
@@ -117,7 +147,16 @@ const renderCartesianSeries = (spec: CartesianChartSpec) => {
 					fill={`var(--color-${series.key})`}
 					fillOpacity={0.24}
 					isAnimationActive={false}
-				/>
+				>
+					{spec.options.showValues ? (
+						<LabelList
+							position="top"
+							offset={10}
+							formatter={formatChartValue}
+							className="fill-foreground text-[11px] font-medium"
+						/>
+					) : null}
+				</Area>
 			));
 	}
 };
@@ -138,9 +177,19 @@ const CartesianChart = ({ spec, className }: { spec: CartesianChartSpec; classNa
 
 	return (
 		<ChartContainer config={config} className={cn("not-prose my-6 w-full min-w-0", className)}>
-			<ChartComponent accessibilityLayer data={spec.data}>
-				<CartesianGrid vertical={false} />
+			<ChartComponent
+				accessibilityLayer
+				data={spec.data}
+				margin={{ top: spec.options.showValues ? 28 : 12, right: 12, left: 12, bottom: 0 }}
+			>
+				{spec.options.hideGrid ? null : <CartesianGrid vertical={false} />}
 				<XAxis dataKey={spec.xKey} tickLine={false} tickMargin={10} axisLine={false} />
+				<YAxis
+					tickLine={false}
+					tickMargin={10}
+					axisLine={false}
+					domain={spec.options.yRange ? [spec.options.yRange.min, spec.options.yRange.max] : undefined}
+				/>
 				<ChartTooltip cursor={false} content={<ChartTooltipContent />} />
 				{spec.options.showLegend ? (
 					<ChartLegend

--- a/src/components/mdx/chart.tsx
+++ b/src/components/mdx/chart.tsx
@@ -2,7 +2,20 @@
 
 import { AlertOctagon } from "lucide-react";
 import { Children, isValidElement, type ReactNode, useMemo, useState } from "react";
-import { Area, AreaChart, Bar, BarChart, CartesianGrid, LabelList, Line, LineChart, Pie, PieChart, XAxis, YAxis } from "recharts";
+import {
+	Area,
+	AreaChart,
+	Bar,
+	BarChart,
+	CartesianGrid,
+	LabelList,
+	Line,
+	LineChart,
+	Pie,
+	PieChart,
+	XAxis,
+	YAxis,
+} from "recharts";
 import {
 	type CartesianChartSpec,
 	CHART_LEGEND_HEIGHT,
@@ -111,7 +124,7 @@ const renderCartesianSeries = (spec: CartesianChartSpec) => {
 							position="top"
 							offset={8}
 							formatter={formatChartValue}
-							className="fill-foreground text-[11px] font-medium"
+							className="fill-foreground font-medium text-[11px]"
 						/>
 					) : null}
 				</Bar>
@@ -132,7 +145,7 @@ const renderCartesianSeries = (spec: CartesianChartSpec) => {
 							position="top"
 							offset={10}
 							formatter={formatChartValue}
-							className="fill-foreground text-[11px] font-medium"
+							className="fill-foreground font-medium text-[11px]"
 						/>
 					) : null}
 				</Line>
@@ -153,7 +166,7 @@ const renderCartesianSeries = (spec: CartesianChartSpec) => {
 							position="top"
 							offset={10}
 							formatter={formatChartValue}
-							className="fill-foreground text-[11px] font-medium"
+							className="fill-foreground font-medium text-[11px]"
 						/>
 					) : null}
 				</Area>

--- a/src/components/mdx/chart.tsx
+++ b/src/components/mdx/chart.tsx
@@ -193,7 +193,7 @@ const CartesianChart = ({ spec, className }: { spec: CartesianChartSpec; classNa
 			<ChartComponent
 				accessibilityLayer
 				data={spec.data}
-				margin={{ top: spec.options.showValues ? 28 : 12, right: 12, left: 12, bottom: 0 }}
+				margin={{ top: spec.options.showValues ? 28 : 12, right: 12, left: 40, bottom: 24 }}
 			>
 				{spec.options.hideGrid ? null : <CartesianGrid vertical={false} />}
 				<XAxis dataKey={spec.xKey} tickLine={false} tickMargin={10} axisLine={false} />
@@ -202,6 +202,7 @@ const CartesianChart = ({ spec, className }: { spec: CartesianChartSpec; classNa
 					tickMargin={10}
 					axisLine={false}
 					domain={spec.options.yRange ? [spec.options.yRange.min, spec.options.yRange.max] : undefined}
+					allowDataOverflow={!!spec.options.yRange}
 				/>
 				<ChartTooltip cursor={false} content={<ChartTooltipContent />} />
 				{spec.options.showLegend ? (

--- a/src/libs/chart/__test__/parse-chart-dsl.test.ts
+++ b/src/libs/chart/__test__/parse-chart-dsl.test.ts
@@ -6,6 +6,9 @@ describe("parseChartDsl", () => {
 		const source = [
 			"chart bar",
 			"x month",
+			"show-values",
+			"hide-grid",
+			"y-range 0 2000",
 			"series views | 조회수 | chart-1",
 			"series likes | 좋아요 | chart-2",
 			"",
@@ -19,6 +22,9 @@ describe("parseChartDsl", () => {
 		expect(parsed.errors).toEqual([]);
 		expect(parsed.type).toBe("bar");
 		expect(parsed.xKey).toBe("month");
+		expect(parsed.showValues).toBe(true);
+		expect(parsed.hideGrid).toBe(true);
+		expect(parsed.yRange).toEqual({ min: 0, max: 2000 });
 		expect(parsed.series).toEqual([
 			{ key: "views", label: "조회수", colorToken: "chart-1" },
 			{ key: "likes", label: "좋아요", colorToken: "chart-2" },
@@ -29,7 +35,13 @@ describe("parseChartDsl", () => {
 		expect(normalized.spec).toMatchObject({
 			type: "bar",
 			xKey: "month",
-			options: { showTooltip: true, showLegend: true },
+			options: {
+				showTooltip: true,
+				showLegend: true,
+				showValues: true,
+				hideGrid: true,
+				yRange: { min: 0, max: 2000 },
+			},
 			series: [
 				{ key: "views", label: "조회수", colorToken: "chart-1" },
 				{ key: "likes", label: "좋아요", colorToken: "chart-2" },
@@ -56,6 +68,12 @@ describe("parseChartDsl", () => {
 		const normalized = normalizeChartDsl(parseChartDsl(source));
 		expect(normalized.errors).toEqual([]);
 		expect(normalized.spec?.options.showLegend).toBe(false);
+		expect(normalized.spec?.type === "line" || normalized.spec?.type === "area" || normalized.spec?.type === "bar"
+			? normalized.spec.options.showValues
+			: undefined).toBe(false);
+		expect(normalized.spec?.type === "line" || normalized.spec?.type === "area" || normalized.spec?.type === "bar"
+			? normalized.spec.options.hideGrid
+			: undefined).toBe(false);
 	});
 
 	it("pie chart DSL을 파싱하고 색상을 자동 배정한다", () => {
@@ -111,6 +129,54 @@ describe("parseChartDsl", () => {
 		expect(normalized.errors).toEqual([{ line: 6, message: "data 헤더에 series key가 모두 포함되어야 합니다." }]);
 	});
 
+	it("y-range 를 정규화 결과에 포함한다", () => {
+		const normalized = normalizeChartDsl(
+			parseChartDsl(
+				[
+					"chart area",
+					"x month",
+					"y-range -10 10",
+					"series delta | 변화량 | chart-1",
+					"",
+					"data",
+					"month | delta",
+					"Jan | -2",
+					"Feb | 7",
+				].join("\n"),
+			),
+		);
+
+		expect(normalized.errors).toEqual([]);
+		expect(normalized.spec).toMatchObject({
+			type: "area",
+			options: { yRange: { min: -10, max: 10 }, showValues: false, hideGrid: false },
+		});
+	});
+
+	it("hide-grid 를 정규화 결과에 포함한다", () => {
+		const normalized = normalizeChartDsl(
+			parseChartDsl(
+				[
+					"chart line",
+					"x month",
+					"hide-grid",
+					"series views | 조회수 | chart-1",
+					"",
+					"data",
+					"month | views",
+					"Jan | 1200",
+					"Feb | 1800",
+				].join("\n"),
+			),
+		);
+
+		expect(normalized.errors).toEqual([]);
+		expect(normalized.spec).toMatchObject({
+			type: "line",
+			options: { hideGrid: true, showValues: false },
+		});
+	});
+
 	it("숫자 필드에 숫자가 아닌 값이 오면 오류를 반환한다", () => {
 		const normalized = normalizeChartDsl(
 			parseChartDsl(
@@ -139,5 +205,50 @@ describe("parseChartDsl", () => {
 		);
 
 		expect(normalized.errors).toEqual([{ line: 7, message: "숫자 필드 visitors 는 비어 있을 수 없습니다." }]);
+	});
+
+	it("잘못된 y-range 문법이면 오류를 반환한다", () => {
+		const parsed = parseChartDsl(
+			["chart bar", "x month", "y-range low high", "series views | 조회수 | chart-1", "", "data", "month | views"].join(
+				"\n",
+			),
+		);
+
+		expect(parsed.errors).toEqual([{ line: 3, message: "y-range 값은 숫자여야 합니다." }]);
+	});
+
+	it("y-range 의 min/max 순서가 잘못되면 오류를 반환한다", () => {
+		const parsed = parseChartDsl(
+			["chart bar", "x month", "y-range 10 0", "series views | 조회수 | chart-1", "", "data", "month | views"].join(
+				"\n",
+			),
+		);
+
+		expect(parsed.errors).toEqual([{ line: 3, message: "y-range 는 min < max 이어야 합니다." }]);
+	});
+
+	it("pie chart에서 cartesian 전용 옵션을 쓰면 오류를 반환한다", () => {
+		const normalized = normalizeChartDsl(
+			parseChartDsl(
+				[
+					"chart pie",
+					"show-values",
+					"hide-grid",
+					"y-range 0 100",
+					"label browser",
+					"value visitors",
+					"",
+					"data",
+					"browser | visitors",
+					"Chrome | 275",
+				].join("\n"),
+			),
+		);
+
+		expect(normalized.errors).toEqual([
+			{ line: 2, message: "pie 차트는 show-values 를 지원하지 않습니다." },
+			{ line: 3, message: "pie 차트는 hide-grid 를 지원하지 않습니다." },
+			{ line: 4, message: "pie 차트는 y-range 를 지원하지 않습니다." },
+		]);
 	});
 });

--- a/src/libs/chart/__test__/parse-chart-dsl.test.ts
+++ b/src/libs/chart/__test__/parse-chart-dsl.test.ts
@@ -68,12 +68,16 @@ describe("parseChartDsl", () => {
 		const normalized = normalizeChartDsl(parseChartDsl(source));
 		expect(normalized.errors).toEqual([]);
 		expect(normalized.spec?.options.showLegend).toBe(false);
-		expect(normalized.spec?.type === "line" || normalized.spec?.type === "area" || normalized.spec?.type === "bar"
-			? normalized.spec.options.showValues
-			: undefined).toBe(false);
-		expect(normalized.spec?.type === "line" || normalized.spec?.type === "area" || normalized.spec?.type === "bar"
-			? normalized.spec.options.hideGrid
-			: undefined).toBe(false);
+		expect(
+			normalized.spec?.type === "line" || normalized.spec?.type === "area" || normalized.spec?.type === "bar"
+				? normalized.spec.options.showValues
+				: undefined,
+		).toBe(false);
+		expect(
+			normalized.spec?.type === "line" || normalized.spec?.type === "area" || normalized.spec?.type === "bar"
+				? normalized.spec.options.hideGrid
+				: undefined,
+		).toBe(false);
 	});
 
 	it("pie chart DSL을 파싱하고 색상을 자동 배정한다", () => {

--- a/src/libs/chart/parse-chart-dsl.ts
+++ b/src/libs/chart/parse-chart-dsl.ts
@@ -16,9 +16,7 @@ const splitTableRow = (line: string) => line.split("|").map((item) => item.trim(
 
 const toError = (line: number, message: string): ChartDslParseError => ({ line, message });
 const isBlankCell = (value: unknown) => typeof value === "string" && value.trim() === "";
-type ParsedNumericRange =
-	| { ok: true; value: { min: number; max: number } }
-	| { ok: false; error: string };
+type ParsedNumericRange = { ok: true; value: { min: number; max: number } } | { ok: false; error: string };
 
 const parseNumericRange = (value: string) => {
 	const [rawMin = "", rawMax = "", ...rest] = value.split(/\s+/).filter(Boolean);

--- a/src/libs/chart/parse-chart-dsl.ts
+++ b/src/libs/chart/parse-chart-dsl.ts
@@ -16,12 +16,36 @@ const splitTableRow = (line: string) => line.split("|").map((item) => item.trim(
 
 const toError = (line: number, message: string): ChartDslParseError => ({ line, message });
 const isBlankCell = (value: unknown) => typeof value === "string" && value.trim() === "";
+type ParsedNumericRange =
+	| { ok: true; value: { min: number; max: number } }
+	| { ok: false; error: string };
+
+const parseNumericRange = (value: string) => {
+	const [rawMin = "", rawMax = "", ...rest] = value.split(/\s+/).filter(Boolean);
+	if (!rawMin || !rawMax || rest.length > 0) {
+		return { ok: false, error: "y-range 줄은 y-range <min> <max> 형식이어야 합니다." } satisfies ParsedNumericRange;
+	}
+
+	const min = Number(rawMin);
+	const max = Number(rawMax);
+	if (!Number.isFinite(min) || !Number.isFinite(max)) {
+		return { ok: false, error: "y-range 값은 숫자여야 합니다." } satisfies ParsedNumericRange;
+	}
+
+	if (min >= max) {
+		return { ok: false, error: "y-range 는 min < max 이어야 합니다." } satisfies ParsedNumericRange;
+	}
+
+	return { ok: true, value: { min, max } } satisfies ParsedNumericRange;
+};
 
 export const parseChartDsl = (source: string): ChartDslParseResult => {
 	const lines = source.replace(/\r\n/g, "\n").split("\n");
 	const errors: ChartDslParseError[] = [];
 	const result: ChartDslParseResult = {
 		source,
+		showValues: false,
+		hideGrid: false,
 		series: [],
 		tableHeaders: [],
 		rows: [],
@@ -66,6 +90,30 @@ export const parseChartDsl = (source: string): ChartDslParseResult => {
 
 		if (trimmed.startsWith("value ")) {
 			result.valueKey = trimmed.slice(6).trim();
+			continue;
+		}
+
+		if (trimmed === "show-values") {
+			result.showValues = true;
+			result.showValuesLine = index + 1;
+			continue;
+		}
+
+		if (trimmed === "hide-grid") {
+			result.hideGrid = true;
+			result.hideGridLine = index + 1;
+			continue;
+		}
+
+		if (trimmed.startsWith("y-range ")) {
+			const parsedRange = parseNumericRange(trimmed.slice(8).trim());
+			if (!parsedRange.ok) {
+				errors.push(toError(index + 1, parsedRange.error));
+				continue;
+			}
+
+			result.yRange = parsedRange.value;
+			result.yRangeLine = index + 1;
 			continue;
 		}
 
@@ -127,6 +175,16 @@ export const normalizeChartDsl = (parsed: ChartDslParseResult): NormalizeChartRe
 	const rowStartLine = (parsed.dataLine ?? 0) + 2;
 
 	if (parsed.type === "pie") {
+		if (parsed.showValues) {
+			errors.push(toError(parsed.showValuesLine ?? 2, "pie 차트는 show-values 를 지원하지 않습니다."));
+		}
+		if (parsed.hideGrid) {
+			errors.push(toError(parsed.hideGridLine ?? 2, "pie 차트는 hide-grid 를 지원하지 않습니다."));
+		}
+		if (parsed.yRange) {
+			errors.push(toError(parsed.yRangeLine ?? 2, "pie 차트는 y-range 를 지원하지 않습니다."));
+		}
+
 		const labelKey = parsed.labelKey;
 		const valueKey = parsed.valueKey;
 
@@ -247,6 +305,9 @@ export const normalizeChartDsl = (parsed: ChartDslParseResult): NormalizeChartRe
 			options: {
 				showTooltip: true,
 				showLegend: parsed.series.length > 1,
+				showValues: parsed.showValues,
+				hideGrid: parsed.hideGrid,
+				yRange: parsed.yRange,
 			},
 		},
 	};

--- a/src/libs/chart/types.ts
+++ b/src/libs/chart/types.ts
@@ -21,6 +21,15 @@ export type ChartDslParseResult = {
 	xKey?: string;
 	labelKey?: string;
 	valueKey?: string;
+	showValues: boolean;
+	showValuesLine?: number;
+	hideGrid: boolean;
+	hideGridLine?: number;
+	yRange?: {
+		min: number;
+		max: number;
+	};
+	yRangeLine?: number;
 	series: ChartDslParseSeries[];
 	tableHeaders: string[];
 	rows: string[][];
@@ -44,6 +53,12 @@ export type CartesianChartSpec = {
 	options: {
 		showTooltip: boolean;
 		showLegend: boolean;
+		showValues: boolean;
+		hideGrid: boolean;
+		yRange?: {
+			min: number;
+			max: number;
+		};
 	};
 };
 


### PR DESCRIPTION
## 변경 내용
- 차트 DSL에 `show-values`, `y-range <min> <max>`, `hide-grid` 옵션을 추가했습니다.
- 막대/라인/영역 차트에서 값 라벨 표시와 y축 범위 고정을 지원하도록 렌더러를 확장했습니다.
- pie 차트에서 cartesian 전용 옵션을 사용할 경우 명시적인 오류를 반환하도록 했습니다.
- 차트 DSL 파서 테스트를 보강해 새 옵션과 오류 케이스를 검증했습니다.

## 변경 이유
게시글에서 차트 값을 바로 읽고 싶고, 비율 데이터처럼 y축 범위를 고정해야 하는 경우가 있으며, 배경 격자선을 숨기고 싶은 경우도 있어서 이를 DSL 수준에서 제어할 수 있게 했습니다.

## 영향
- 기존 차트 문법은 그대로 유지됩니다.
- 필요한 경우에만 새 옵션을 추가해서 차트 표현을 더 세밀하게 조정할 수 있습니다.

## 검증
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run src/libs/chart/__test__/parse-chart-dsl.test.ts src/components/mdx/__test__/mdx-content.chart.test.tsx`