### PR TITLE
[codex] 차트 DSL에 y축 숨김 옵션 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ chart bar
 x month
 show-values
 hide-grid
+hide-y-axis
 y-range 0 2400
 series views | 조회수 | chart-1
 series likes | 좋아요 | chart-2
@@ -187,6 +188,7 @@ Mar | 1940 | 260
 - `x <field>`는 필수
 - `show-values`를 넣으면 각 데이터 값이 차트 위에 표시됩니다.
 - `hide-grid`를 넣으면 배경 격자선을 숨깁니다.
+- `hide-y-axis`를 넣으면 y축 숫자와 축 표시를 숨깁니다.
 - `y-range <min> <max>`를 넣으면 y축 범위를 고정합니다.
 - `series <key> | <label> | <theme-token>`은 1개 이상 필요
 - 빈 줄 뒤에 `data`
@@ -195,7 +197,7 @@ Mar | 1940 | 260
 
 색상 토큰은 `chart-1`부터 `chart-5`까지만 허용합니다.
 
-쉽게 말하면, 기본 문법은 그대로 두고 필요할 때만 `show-values`, `hide-grid`, `y-range` 같은 줄을 추가해서 차트 모양을 조절하는 방식입니다.
+쉽게 말하면, 기본 문법은 그대로 두고 필요할 때만 `show-values`, `hide-grid`, `hide-y-axis`, `y-range` 같은 줄을 추가해서 차트 모양을 조절하는 방식입니다.
 
 ### Pie 차트
 
@@ -216,7 +218,7 @@ Edge | 132
 - `label <field>`는 항목 이름 필드
 - `value <field>`는 숫자 값 필드
 - 색상은 행 순서대로 `chart-1` ~ `chart-5`가 자동 배정
-- `show-values`, `hide-grid`, `y-range`는 pie 차트에서 지원하지 않습니다.
+- `show-values`, `hide-grid`, `hide-y-axis`, `y-range`는 pie 차트에서 지원하지 않습니다.
 
 ### 오류 처리
 

--- a/src/components/mdx/chart.tsx
+++ b/src/components/mdx/chart.tsx
@@ -193,11 +193,12 @@ const CartesianChart = ({ spec, className }: { spec: CartesianChartSpec; classNa
 			<ChartComponent
 				accessibilityLayer
 				data={spec.data}
-				margin={{ top: spec.options.showValues ? 28 : 12, right: 12, left: 40, bottom: 24 }}
+				margin={{ top: spec.options.showValues ? 28 : 12, right: 12, left: spec.options.hideYAxis ? 12 : 40, bottom: 24 }}
 			>
 				{spec.options.hideGrid ? null : <CartesianGrid vertical={false} />}
 				<XAxis dataKey={spec.xKey} tickLine={false} tickMargin={10} axisLine={false} />
 				<YAxis
+					hide={spec.options.hideYAxis}
 					tickLine={false}
 					tickMargin={10}
 					axisLine={false}

--- a/src/libs/chart/__test__/parse-chart-dsl.test.ts
+++ b/src/libs/chart/__test__/parse-chart-dsl.test.ts
@@ -8,6 +8,7 @@ describe("parseChartDsl", () => {
 			"x month",
 			"show-values",
 			"hide-grid",
+			"hide-y-axis",
 			"y-range 0 2000",
 			"series views | 조회수 | chart-1",
 			"series likes | 좋아요 | chart-2",
@@ -24,6 +25,7 @@ describe("parseChartDsl", () => {
 		expect(parsed.xKey).toBe("month");
 		expect(parsed.showValues).toBe(true);
 		expect(parsed.hideGrid).toBe(true);
+		expect(parsed.hideYAxis).toBe(true);
 		expect(parsed.yRange).toEqual({ min: 0, max: 2000 });
 		expect(parsed.series).toEqual([
 			{ key: "views", label: "조회수", colorToken: "chart-1" },
@@ -40,6 +42,7 @@ describe("parseChartDsl", () => {
 				showLegend: true,
 				showValues: true,
 				hideGrid: true,
+				hideYAxis: true,
 				yRange: { min: 0, max: 2000 },
 			},
 			series: [
@@ -76,6 +79,11 @@ describe("parseChartDsl", () => {
 		expect(
 			normalized.spec?.type === "line" || normalized.spec?.type === "area" || normalized.spec?.type === "bar"
 				? normalized.spec.options.hideGrid
+				: undefined,
+		).toBe(false);
+		expect(
+			normalized.spec?.type === "line" || normalized.spec?.type === "area" || normalized.spec?.type === "bar"
+				? normalized.spec.options.hideYAxis
 				: undefined,
 		).toBe(false);
 	});
@@ -177,7 +185,31 @@ describe("parseChartDsl", () => {
 		expect(normalized.errors).toEqual([]);
 		expect(normalized.spec).toMatchObject({
 			type: "line",
-			options: { hideGrid: true, showValues: false },
+			options: { hideGrid: true, hideYAxis: false, showValues: false },
+		});
+	});
+
+	it("hide-y-axis 를 정규화 결과에 포함한다", () => {
+		const normalized = normalizeChartDsl(
+			parseChartDsl(
+				[
+					"chart line",
+					"x month",
+					"hide-y-axis",
+					"series views | 조회수 | chart-1",
+					"",
+					"data",
+					"month | views",
+					"Jan | 1200",
+					"Feb | 1800",
+				].join("\n"),
+			),
+		);
+
+		expect(normalized.errors).toEqual([]);
+		expect(normalized.spec).toMatchObject({
+			type: "line",
+			options: { hideGrid: false, hideYAxis: true, showValues: false },
 		});
 	});
 
@@ -238,6 +270,7 @@ describe("parseChartDsl", () => {
 					"chart pie",
 					"show-values",
 					"hide-grid",
+					"hide-y-axis",
 					"y-range 0 100",
 					"label browser",
 					"value visitors",
@@ -252,7 +285,8 @@ describe("parseChartDsl", () => {
 		expect(normalized.errors).toEqual([
 			{ line: 2, message: "pie 차트는 show-values 를 지원하지 않습니다." },
 			{ line: 3, message: "pie 차트는 hide-grid 를 지원하지 않습니다." },
-			{ line: 4, message: "pie 차트는 y-range 를 지원하지 않습니다." },
+			{ line: 4, message: "pie 차트는 hide-y-axis 를 지원하지 않습니다." },
+			{ line: 5, message: "pie 차트는 y-range 를 지원하지 않습니다." },
 		]);
 	});
 });

--- a/src/libs/chart/parse-chart-dsl.ts
+++ b/src/libs/chart/parse-chart-dsl.ts
@@ -44,6 +44,7 @@ export const parseChartDsl = (source: string): ChartDslParseResult => {
 		source,
 		showValues: false,
 		hideGrid: false,
+		hideYAxis: false,
 		series: [],
 		tableHeaders: [],
 		rows: [],
@@ -100,6 +101,12 @@ export const parseChartDsl = (source: string): ChartDslParseResult => {
 		if (trimmed === "hide-grid") {
 			result.hideGrid = true;
 			result.hideGridLine = index + 1;
+			continue;
+		}
+
+		if (trimmed === "hide-y-axis") {
+			result.hideYAxis = true;
+			result.hideYAxisLine = index + 1;
 			continue;
 		}
 
@@ -178,6 +185,9 @@ export const normalizeChartDsl = (parsed: ChartDslParseResult): NormalizeChartRe
 		}
 		if (parsed.hideGrid) {
 			errors.push(toError(parsed.hideGridLine ?? 2, "pie 차트는 hide-grid 를 지원하지 않습니다."));
+		}
+		if (parsed.hideYAxis) {
+			errors.push(toError(parsed.hideYAxisLine ?? 2, "pie 차트는 hide-y-axis 를 지원하지 않습니다."));
 		}
 		if (parsed.yRange) {
 			errors.push(toError(parsed.yRangeLine ?? 2, "pie 차트는 y-range 를 지원하지 않습니다."));
@@ -305,6 +315,7 @@ export const normalizeChartDsl = (parsed: ChartDslParseResult): NormalizeChartRe
 				showLegend: parsed.series.length > 1,
 				showValues: parsed.showValues,
 				hideGrid: parsed.hideGrid,
+				hideYAxis: parsed.hideYAxis,
 				yRange: parsed.yRange,
 			},
 		},

--- a/src/libs/chart/types.ts
+++ b/src/libs/chart/types.ts
@@ -25,6 +25,8 @@ export type ChartDslParseResult = {
 	showValuesLine?: number;
 	hideGrid: boolean;
 	hideGridLine?: number;
+	hideYAxis: boolean;
+	hideYAxisLine?: number;
 	yRange?: {
 		min: number;
 		max: number;
@@ -55,6 +57,7 @@ export type CartesianChartSpec = {
 		showLegend: boolean;
 		showValues: boolean;
 		hideGrid: boolean;
+		hideYAxis: boolean;
 		yRange?: {
 			min: number;
 			max: number;


### PR DESCRIPTION
## 변경 내용
- 차트 DSL에 `hide-y-axis` 옵션을 추가했습니다.
- cartesian 차트에서 `hide-y-axis`를 사용하면 y축 숫자와 축 표시를 숨기도록 렌더러를 확장했습니다.
- y축을 숨기는 경우 왼쪽 여백도 함께 줄여 차트가 불필요하게 오른쪽으로 밀리지 않도록 조정했습니다.
- pie 차트에서 `hide-y-axis`를 사용할 경우 명시적인 오류를 반환하도록 파서와 테스트를 보강했습니다.
- README의 Chart DSL 문서에 새 옵션 설명을 추가했습니다.

## 변경 이유
기존에는 y축 범위를 계산에 사용하더라도 화면에서는 항상 y축이 보였습니다. 게시글 안에서 더 간결한 차트를 만들고 싶을 때 y축을 선택적으로 숨길 수 있어야 해서 DSL 옵션으로 제어할 수 있게 했습니다.

## 영향
- 기존 차트는 그대로 동작합니다.
- 필요한 경우에만 `hide-y-axis`를 추가해서 y축을 숨길 수 있습니다.

## 검증
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run src/libs/chart/__test__/parse-chart-dsl.test.ts src/components/mdx/__test__/mdx-content.chart.test.tsx`